### PR TITLE
devops.pf -> tahiti.dev

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-www.devops.pf
+tahiti.dev

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 Creative Commons Attribution 3.0 Unported
-http://creativecommons.org/licenses/by/3.0/
+https://creativecommons.org/licenses/by/3.0/
 
 License
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,11 @@
 # Site settings
 title: Tahiti
 subtitle: DevOps
-email: contact@devops.pf
+email: contact@tahiti.dev
 description: POUR QUE DEV ET OPS SE COMPRENNENT, ET POUR FAIRE PRENDRE CONSCIENCE DE L'IMPORTANCE SOCIALE DE L'INFORMATIQUE.
 baseurl: ""
-url: "http://www.devops.pf"
-author: devops.pf
+url: "http://www.tahiti.dev"
+author: tahiti.dev
 street_address: BP 40855
 city: Papeete
 state: Tahiti

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ subtitle: DevOps
 email: contact@tahiti.dev
 description: POUR QUE DEV ET OPS SE COMPRENNENT, ET POUR FAIRE PRENDRE CONSCIENCE DE L'IMPORTANCE SOCIALE DE L'INFORMATIQUE.
 baseurl: ""
-url: "http://www.tahiti.dev"
+url: "https://www.tahiti.dev"
 author: tahiti.dev
 street_address: BP 40855
 city: Papeete
@@ -15,14 +15,14 @@ phone: (+689) 87 344 610
 
 # Social settings
 500px_url:
-facebook_url: http://fb.me/TahitiDevOps
+facebook_url: https://fb.me/TahitiDevOps
 github_url: https://github.com/tahitidevops
 gitlab_url:
 googleplus_url:
 instagram_url:
 linkedin_url:
 pinterest_url:
-slack_url: http://tahitidevops.slack.com
+slack_url: https://tahitidevops.slack.com
 twitter_url: https://twitter.com/tahitidevops
 meetup_url: https://www.meetup.com/TahitiDevOps
 conference_server: https://meet.polynesie-francaise.pf/devops

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -16,7 +16,7 @@
           </header>
           <ul>
             <li><a href="/">Accueil</a></li>
-            <li><a href="https://map.devops.pf">Qui sommes-nous ?</a></li>
+            <li><a href="https://map.tahiti.dev">Qui sommes-nous ?</a></li>
             <li><a href="/code.html">Code de conduite</a></li>
             <li>
               <span class="opener">L'Association</span>

--- a/code.md
+++ b/code.md
@@ -44,5 +44,5 @@ title: Code de conduite
 </div>
 
 <h3 id="content">Attribution</h3>
-<p>Ce Code de Conduite est adaptée du Contributor Covenant (http://contributor-covenant.org), version 1.4.0, disponible à http://contributor-covenant.org/version/1/4/0/fr</p>
+<p>Ce Code de Conduite est adaptée du Contributor Covenant (https://contributor-covenant.org), version 1.4.0, disponible à https://contributor-covenant.org/version/1/4/0/fr</p>
 <hr class="major" />

--- a/index.md
+++ b/index.md
@@ -215,7 +215,7 @@ layout: default
                 <h3>005 - OpenPGP et réseau de confiance</h3>
                 <h4>David PRÉVOT</h4>
                 <p>
-                    Lors de ce meetup, David vous présentera: les concepts de OpenPGP (signature, chiffrement), les bonnes pratiques (date d’expiration, sous-clefs, stockage…), l'intérêt du réseau de confiance, les signatures de clefs, et l'accès au « strong set » (<a href="http://www.devops.pf/assets/pdfs/tdo_005.pdf">Slides de la présentation</a>).
+                    Lors de ce meetup, David vous présentera: les concepts de OpenPGP (signature, chiffrement), les bonnes pratiques (date d’expiration, sous-clefs, stockage…), l'intérêt du réseau de confiance, les signatures de clefs, et l'accès au « strong set » (<a href="/assets/pdfs/tdo_005.pdf">Slides de la présentation</a>).
                 </p>
                 <ul class="actions">
                     <li><a href="https://www.meetup.com/fr-FR/TahitiDevOps/events/247046773/" class="button">lundi 12 février 2018</a></li>


### PR DESCRIPTION
The site will be reachable at https://tahitidevops.github.io/

```sh-session
romain@desktop-fln40kq ~ % whois devops.pf
This is the PF top level domain whois server.
Informations about 'devops.pf' :

Domain unknown
```
